### PR TITLE
Remove flush() from ChunkedTransferSocket header() and write()

### DIFF
--- a/AWSTransport.php
+++ b/AWSTransport.php
@@ -157,7 +157,6 @@
 		public function header ( $header, $value ) {
 			if( $this->write_started ) { throw new InvalidOperationException( "Can not write header, body writing has started." ); }
 			fwrite( $this->socket, "$header: $value\r\n" );
-			flush( $this->socket );
 		}
 		
 		/**
@@ -174,7 +173,6 @@
 			
 			fwrite( $this->socket, sprintf( "%x\r\n", strlen( $chunk ) ) );
 			fwrite( $this->socket, $chunk . "\r\n" );
-			flush( $this->socket );
 		}
 		
 		/**


### PR DESCRIPTION
Hi,

Thanks for writing this transport!  It came in real handy!

One thing I noticed though is that PHP's [flush()](http://php.net/manual/en/function.flush.php) does not take a socket to flush, but instead sends data to the browser.

So any attempt to set headers after ending an email throw errors.

It looks like AWSInputByteStream::flushBuffers should be doing what's needed here, but either way these flushes don't seem to be serving any real purpose.

-Matt
