### PR TITLE
Change debugging echo's to error_log()s

### DIFF
--- a/classes/Swift/AWSTransport.php
+++ b/classes/Swift/AWSTransport.php
@@ -100,9 +100,9 @@
 			$this->response = $this->_doSend($message, $failedRecipients);
 
 			if( defined('SWIFT_AWS_DEBUG') || $this->debug ) {
-				echo "=== Start AWS Response ===\r\n";
-				echo $this->response->body;
-				echo "===	End AWS Response	===\r\n";
+				error_log("=== Start AWS Response ===");
+				error_log($this->response->body);
+				error_log("=== End AWS Response ===");
 			}
 
 			$success = (200 == $this->response->code);


### PR DESCRIPTION
This debugging information is useful, but by using echo to log it, we corrupt our output which is especially painful when the output was supposed to be a valid JSON encoded message.

Using `error_log` might be a better solution.
