### PR TITLE
Check if debug function is_callable before execution.

### DIFF
--- a/classes/Swift/AWSTransport.php
+++ b/classes/Swift/AWSTransport.php
@@ -84,9 +84,11 @@
 		}
 
 		protected function _debug ( $message ) {
-			if( false === $this->debug ) { return; }
-			if( true === $this->debug ) { error_log( $message ); }
-			else { call_user_func( $this->debug, $message ); }
+			if ( true === $this->debug ) {
+				error_log( $message );
+			} elseif ( is_callable($this->debug) ) {
+				call_user_func( $this->debug, $message );
+			}
 		}
 
 		/**


### PR DESCRIPTION
Cases where configuration variables do not evaulate to true/false result in errors when Swift
attempts to call that value as a function.
