### PR TITLE
Add option to reuse socket between sends.

### DIFF
--- a/classes/Swift/AWSTransport.php
+++ b/classes/Swift/AWSTransport.php
@@ -21,6 +21,8 @@
 		private $AWSSecretKey;
 		/** the service endpoint */
 		private $endpoint;
+		/** be persistent? **/
+		private $persistent;
 		/**
 		 * Debugging helper.
 		 *
@@ -33,6 +35,8 @@
 		private $debug;
 		/** the response */
 		private $response;
+		/** the raw socket */
+		private $fp;
 
 		/**
 		* Create a new AWSTransport.
@@ -41,7 +45,7 @@
 		* @param boolean $debug Set to true to enable debug messages in error log.
 		* @param string $endpoint The AWS endpoint to use.
 		*/
-		public function __construct($AWSAccessKeyId = null , $AWSSecretKey = null, $debug = false, $endpoint = 'https://email.us-east-1.amazonaws.com/') {
+		public function __construct($AWSAccessKeyId = null , $AWSSecretKey = null, $debug = false, $endpoint = 'https://email.us-east-1.amazonaws.com/', $persistent = false) {
 			call_user_func_array(
 				array($this, 'Swift_Transport_AWSTransport::__construct'),
 				Swift_DependencyContainer::getInstance()
@@ -52,6 +56,13 @@
 			$this->AWSSecretKey = $AWSSecretKey;
 			$this->endpoint = $endpoint;
 			$this->debug = $debug;
+			$this->persistent = $persistent;
+		}
+
+		public function __destruct() {
+			if( $this->fp ) { 
+				@fclose( $this->fp );
+			}
 		}
 
 		/**
@@ -76,7 +87,17 @@
 		}
 
 		public function setEndpoint($val) {
+			if( $this->fp ) {
+				@fclose( $this->fp );
+			}
 			$this->endpoint = $val;
+		}
+
+		public function setPersistent($val) {
+			if( $this->fp && ! $val ) { 
+				@fclose( $this->fp );
+			}
+			$this->persistent = $val;
 		}
 
 		public function getResponse() {
@@ -138,6 +159,26 @@
 			}
 		}
 
+		protected function getRawSocket () {
+
+			if( ! $this->persistent || ! $this->fp ) {
+				$host = parse_url( $this->endpoint, PHP_URL_HOST );
+				$path = parse_url( $this->endpoint, PHP_URL_PATH );
+
+				$fp = fsockopen( 'ssl://' . $host, 443, $errno, $errstr, 30 );
+
+				if( ! $fp ) {
+					throw new AWSConnectionError( "$errstr ($errno)" );
+				}
+
+				if( $this->persistent ) {
+					$this->fp = $fp;
+				}
+			}
+
+			return ( $this->persistent ) ? $this->fp : $fp;
+		}
+
 		/**
 		 * do send through the API
 		 *
@@ -156,16 +197,11 @@
 			}
 			$auth = "AWS3-HTTPS AWSAccessKeyId=" . $this->AWSAccessKeyId . ", Algorithm=HmacSHA1, Signature=" . $hmac;
 
+			$fp = $this->getRawSocket();
 			$host = parse_url( $this->endpoint, PHP_URL_HOST );
 			$path = parse_url( $this->endpoint, PHP_URL_PATH );
 
-			$fp = fsockopen( 'ssl://' . $host , 443, $errno, $errstr, 30 );
-
-			if( ! $fp ) {
-				throw new AWSConnectionError( "$errstr ($errno)" );
-			}
-
-			$socket = new ChunkedTransferSocket( $fp, $host, $path );
+			$socket = new ChunkedTransferSocket( $fp, $host, $path, "POST", $this->persistent );
 
 			$socket->header("Date", $date);
 			$socket->header("X-Amzn-Authorization", $auth);
@@ -177,6 +213,10 @@
 			$ais->flushBuffers();
 
 			$result = $socket->read();
+
+			if( ! $this->persistent ) {
+				fclose($fp);
+			}
 
 			return $result;
 		}
@@ -223,21 +263,24 @@
 		 * @param $host
 		 * @param $path
 		 * @param $method
+		 * @param $persistent
 		 */
-		public function __construct( $socket, $host, $path, $method="POST" ) {
+		public function __construct( $socket, $host, $path, $method="POST", $persistent=false ) {
 
 			$this->socket = $socket;
+			$this->persistent = $persistent;
+
 			$this->write_started = false;
 			$this->write_finished = false;
 			$this->read_started = false;
-
+			
 			fwrite( $this->socket, "$method $path HTTP/1.1\r\n" );
 
 			$this->header( "Host", $host );
 			if( "POST" == $method ) {
 				$this->header( "Content-Type", "application/x-www-form-urlencoded" );
 			}
-			$this->header( "Connection", "close" );
+			$this->header( "Connection", ( $this->persistent ) ? 'keep-alive' : 'close' );
 			$this->header( "Transfer-Encoding", "chunked" );
 		}
 
@@ -264,9 +307,10 @@
 				fwrite( $this->socket, "\r\n" ); // Start message body
 				$this->write_started = true;
 			}
-
+	
 			fwrite( $this->socket, sprintf( "%x\r\n", strlen( $chunk ) ) );
-			fwrite( $this->socket, $chunk . "\r\n" );
+			fwrite( $this->socket, $chunk );
+			fwrite( $this->socket, "\r\n" );
 			fflush( $this->socket );
 		}
 
@@ -287,10 +331,12 @@
 
 			$response = new AWSResponse();
 			while( ! feof( $this->socket ) ) {
-				$response->line( fgets( $this->socket ) );
+				$line = fgets( $this->socket );
+				if( AWSResponse::EOF == $response->line( $line ) ) {
+					break;
+				}
 			}
 			$response->complete();
-			fclose( $this->socket );
 
 			return $response;
 		}
@@ -307,12 +353,16 @@
 		public $message = '';
 		public $body = '';
 		public $xml = null;
+		public $content_length;
 
 		const STATE_EMPTY = 0;
 		const STATE_HEADERS = 1;
 		const STATE_BODY = 2;
 
+		const EOF = 'EOF';
+
 		protected $state = self::STATE_EMPTY;
+		protected $content_length_received = 0;
 
 		public function line ( $line ) {
 
@@ -335,10 +385,19 @@
 					$pos = strpos( $line, ':' );
 					if( false === $pos ) { throw new InvalidHeaderException( $line ); }
 					$key = substr( $line, 0, $pos );
-					$this->headers[$key] = substr( $line, $pos );
+					$this->headers[$key] = substr( $line, $pos + 2, strlen($line) - $pos - 4 );
+
+					if( strtolower($key) == 'content-length' ) {
+						$this->content_length = intval($this->headers[$key]);
+					}
+
 					break;
 				case self::STATE_BODY:
+					$this->content_length_received += strlen($line);
 					$this->body .= $line;
+					if( isset( $this->content_length ) and $this->content_length_received >= $this->content_length ) {
+						return self::EOF;
+					}
 					break;
 			}
 

--- a/example/send-multiple.php
+++ b/example/send-multiple.php
@@ -6,11 +6,12 @@
 	 * 2. Copy config.php.example to config.php and add your AWS credentials
 	 * 3. Run this script!
 	 */
-	require_once(__DIR__ . '/../vendor/autoload.php');
+  require_once(__DIR__ . '/../vendor/autoload.php');
 	require_once('./config.php');
 
 	$transport = Swift_AWSTransport::newInstance( AWSAccessKeyId, AWSSecretKey );
 	$transport->setDebug( true ); // Print the response from AWS to the error log for debugging.
+  $transport->setPersistent( true ); // Reuse the socket
 
 	//Create the Mailer using your created Transport
 	$mailer = Swift_Mailer::newInstance( $transport );
@@ -23,10 +24,26 @@
 	->setBody( "<p>Dude, I'm <b>totally</b> sending you email via AWS.</p>", 'text/html' )
 	->addPart( "Dude, I'm _totally_ sending you email via AWS.", 'text/plain' );
 
-	echo "Sending\n\n";
-	echo "From: " . FROM_ADDRESS . "\n";
-	echo "  To: " . TO_ADDRESS . "\n";
+  echo "Sending\n\n";
+  echo "From: " . FROM_ADDRESS . "\n";
+  echo "  To: " . TO_ADDRESS . "\n";
+	try {
+		echo "Sent: " . $mailer->send( $message ) . "\n";
+	}
+	catch( AWSEmptyResponseException $e ) {
+		echo $e . "\n";
+  }
 
+	$message = Swift_Message::newInstance()
+	->setSubject( 'Testing Swiftmailer SES AGAIN!' )
+	->setFrom( array( FROM_ADDRESS ) )
+	->setTo( array( TO_ADDRESS ) )
+	->setBody( "<p>Dude, I'm <b>totally</b> sending you email via AWS and the SAME SOCKET.</p>", 'text/html' )
+	->addPart( "Dude, I'm _totally_ sending you email via AWS and the SAME SOCKET.", 'text/plain' );
+
+  echo "Sending\n\n";
+  echo "From: " . FROM_ADDRESS . "\n";
+  echo "  To: " . TO_ADDRESS . "\n";
 	try {
 		echo "Sent: " . $mailer->send( $message ) . "\n";
 	}


### PR DESCRIPTION
Experimental feature, solves #25.

Not 100% solid on this, it needs more review, testing and discussion.

It's got the bare minimum HTTP parsing to use `keep-alive`.  There isn't much in the way of a safety net.
