### PR TITLE
Added __toString() method to Response object

### DIFF
--- a/classes/Swift/Response/AWSResponse.php
+++ b/classes/Swift/Response/AWSResponse.php
@@ -31,6 +31,25 @@ class Swift_Response_AWSResponse {
 	}
 
 	/**
+	 * @return string
+	 */
+	function __toString()
+    	{
+		if(!$this->getBody())
+			return "No response body available.";
+
+		//success
+		if($this->getBody()->ResponseMetadata)
+			return "Success! RequestId: " . $this->getBody()->ResponseMetadata->RequestId;
+
+		//failure
+		if($this->getBody()->Error && $this->getBody()->Error->Message)
+			return (string) $this->getBody()->Error->Message;
+
+		return "Unknown Response";
+    	}
+	
+	/**
 	 * @return Swift_Mime_Message
 	 */
 	function getMessage()


### PR DESCRIPTION
Swiftmailer's PSR logger plugin requires Response objects to return strings.