### PR TITLE
SwiftMailer 6 support

### DIFF
--- a/classes/Swift/AWSTransport.php
+++ b/classes/Swift/AWSTransport.php
@@ -97,12 +97,12 @@
 		* Recipient/sender data will be retreived from the Message API.
 		* The return value is the number of recipients who were accepted for delivery.
 		*
-		* @param Swift_Mime_Message $message
+		* @param Swift_Mime_SimpleMessage $message
 		* @param string[] &$failedRecipients to collect failures by-reference
 		* @return int
 		* @throws AWSConnectionError
 		*/
-		public function send( Swift_Mime_Message $message, &$failedRecipients = null ) {
+		public function send( Swift_Mime_SimpleMessage $message, &$failedRecipients = null ) {
 
 			if ($evt = $this->_eventDispatcher->createSendEvent($this, $message))
 			{
@@ -142,11 +142,11 @@
 		/**
 		 * do send through the API
 		 *
-		 * @param Swift_Mime_Message $message
+		 * @param Swift_Mime_SimpleMessage $message
 		 * @param string[] &$failedRecipients to collect failures by-reference
 		 * @return AWSResponse
 		 */
-		protected function _doSend( Swift_Mime_Message $message, &$failedRecipients = null )
+		protected function _doSend( Swift_Mime_SimpleMessage $message, &$failedRecipients = null )
 		{
 			$date = date( 'D, j F Y H:i:s O' );
 			if( function_exists( 'hash_hmac' ) and in_array( 'sha1', hash_algos() ) ) {

--- a/classes/Swift/AWSTransport.php
+++ b/classes/Swift/AWSTransport.php
@@ -139,6 +139,10 @@
 			}
 		}
 
+        public function ping() {
+            return true;
+        }
+
 		/**
 		 * do send through the API
 		 *

--- a/classes/Swift/Response/AWSResponse.php
+++ b/classes/Swift/Response/AWSResponse.php
@@ -2,7 +2,7 @@
 
 class Swift_Response_AWSResponse {
 	/**
-	 * @var Swift_Mime_Message
+	 * @var Swift_Mime_SimpleMessage
 	 */
 	protected $message;
 
@@ -19,11 +19,11 @@ class Swift_Response_AWSResponse {
 	/**
 	 * Swift_Response_AWSResponse constructor.
 	 *
-	 * @param Swift_Mime_Message $message
+	 * @param Swift_Mime_SimpleMessage $message
 	 * @param null $body
 	 * @param bool $success
 	 */
-	public function __construct( Swift_Mime_Message $message, $body = null, $success = false )
+	public function __construct( Swift_Mime_SimpleMessage $message, $body = null, $success = false )
 	{
 		$this->message = $message;
 		$this->body = $body;
@@ -50,7 +50,7 @@ class Swift_Response_AWSResponse {
     	}
 	
 	/**
-	 * @return Swift_Mime_Message
+	 * @return Swift_Mime_SimpleMessage
 	 */
 	function getMessage()
 	{

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
 		}
 	],
 	"require": {
-		"php": ">=5.2.0",
-		"swiftmailer/swiftmailer": ">=4.0.0"
+		"php": "^7.0",
+		"swiftmailer/swiftmailer": "^6.0"
 	},
 	"autoload": {
 		"psr-0": { "": "classes/" }


### PR DESCRIPTION
This patch provides the changes needed to get the transport to work with version 6 releases of SwiftMailer. They include:

- Typehinting against `Swift_Mime_SimpleMessage` instead of `Swift_Mime_Message` in both the transport and response (this was an API change in version 6).
- Adding a `ping()` method to `Swift_AWSTransport`. I've simply made it return `true`; it might make sense to have it issue a `HEAD` request or similar to the AWS SES endpoint.

I've tested this locally, and it works correctly.