### PR TITLE
Validate path before creating connection

### DIFF
--- a/classes/Swift/AWSTransport.php
+++ b/classes/Swift/AWSTransport.php
@@ -165,6 +165,9 @@
 			if( ! $this->persistent || ! $this->fp ) {
 				$host = parse_url( $this->endpoint, PHP_URL_HOST );
 				$path = parse_url( $this->endpoint, PHP_URL_PATH );
+				if (is_null($path)) {
+					$path = '/';
+				}
 
 				$fp = fsockopen( 'ssl://' . $host, 443, $errno, $errstr, 30 );
 
@@ -205,6 +208,9 @@
 			$fp = $this->getRawSocket();
 			$host = parse_url( $this->endpoint, PHP_URL_HOST );
 			$path = parse_url( $this->endpoint, PHP_URL_PATH );
+			if (is_null($path)) {
+				$path = '/';
+			}
 
 			$socket = new ChunkedTransferSocket( $fp, $host, $path, "POST", $this->persistent );
 


### PR DESCRIPTION
When the configured endpoint does not end in a trailing slash, the path will be NULL, resulting in a distracting "505 HTTP Version not supported" error from Amazon.

---

It took me quite some time to debug this so hopefully this'll save the next guy some time and effort.
I've chosen to normalize the path in this case. An alternative solution would be to throw an exception, but I think this is the better solution in this case, not bothering developers with implementation details.

Let me know what you think!