### PR TITLE
Parameters of implode() function reversed throws deprecation notice since PHP 7.4.0

### DIFF
--- a/classes/Swift/AWSTransport.php
+++ b/classes/Swift/AWSTransport.php
@@ -403,7 +403,7 @@
 					}
 					$split = explode( ' ', $line );
 					$this->code = $split[1];
-					$this->message = implode( array_slice( $split, 2 ), ' ' );
+					$this->message = implode( ' ', array_slice( $split, 2 ) );
 					$this->state = self::STATE_HEADERS;
 					break;
 				case self::STATE_HEADERS:


### PR DESCRIPTION
The function `implode()` on line 400 of AWSTransport.php has the order of parameters ($glue, $pieces) reversed:
`$this->message = implode( array_slice( $split, 2 ), ' ' );`

This throws a deprecation notice from PHP 7.4.0 on. See this relevant [changelog on php.net](https://www.php.net/manual/en/function.implode.php#refsect1-function.implode-changelog).